### PR TITLE
Fix typo "Togin"->"Tigon"

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Your contributions are always welcome!
 ## Frameworks
 
 * [Apache Hadoop](http://hadoop.apache.org/) - framework for distributed processing. Integrates MapReduce (parallel processing), YARN (job scheduling) and HDFS (distributed file system).
-* [Togin](https://github.com/caskdata/tigon) - High Throughput Real-time Stream Processing Framework.
+* [Tigon](https://github.com/caskdata/tigon) - High Throughput Real-time Stream Processing Framework.
 
 ## Distributed Programming
 


### PR DESCRIPTION
There is typo of "Tigon"