### PR TITLE
Add Bonnard - agentic schema layer with multi-warehouse MCP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Your contributions are always welcome!
 ## Frameworks
 
 * [Bistro](https://github.com/facebook/bistro) - general-purpose data processing engine for both batch and stream analytics. It is based on a novel data model, which represents data via *functions* and processes data via *column operations* as opposed to having only set operations in conventional approaches like MapReduce or SQL.
+* [Bonnard](https://bonnard.dev) - Open-source agentic schema for reliable data outputs. Query data through MCP and via our SDK. Create apps, embed data or explore through your preferred agent.
 * [IBM Streams](https://www.ibm.com/analytics/us/en/technology/stream-computing/) - platform for distributed processing and real-time analytics.  Integrates with many of the popular technologies in the Big Data ecosystem (Kafka, HDFS, Spark, etc.)
 * [Apache Hadoop](http://hadoop.apache.org/) - framework for distributed processing. Integrates MapReduce (parallel processing), YARN (job scheduling) and HDFS (distributed file system).
 * [Tigon](https://github.com/caskdata/tigon) - High Throughput Real-time Stream Processing Framework.


### PR DESCRIPTION
Adds Bonnard to the Frameworks section.

Bonnard is an open-source agentic schema for reliable data outputs. Apache 2.0 licensed. Supports Snowflake, BigQuery, Databricks, PostgreSQL, and DuckDB via MCP, REST, or SQL.

Website: https://bonnard.dev
GitHub: https://github.com/bonnard-data/bonnard