### PR TITLE
Add stratif.io to Business Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,6 +626,7 @@ You can read more about this distinction on Prof. Daniel Abadi's blog: [Distingu
 * [Saiku Analytics](https://www.meteorite.bi/) - Open source analytics platform.
 * [Knowage](https://www.knowage-suite.com/) - open source business intelligence platform. (former [SpagoBi](http://www.spagobi.org/))
 * [SparklineData SNAP](http://sparklinedata.com/) - modern B.I platform powered by Apache Spark.
+* [stratif.io](https://stratif.io) - Self-hosted, open-source product analytics that runs directly on your DuckDB, Postgres, Snowflake, or ClickHouse warehouse.
 * [Tableau](https://www.tableau.com/) - business intelligence platform.
 * [Zoomdata](https://www.zoomdata.com/) - Big Data Analytics.
 


### PR DESCRIPTION
Adds stratif.io to the Business Intelligence section.

stratif.io is an open-source (Apache-2.0), self-hosted warehouse-native product analytics tool. It runs funnels, retention, and path analysis directly on your existing SQL warehouse (DuckDB, Postgres, Snowflake, ClickHouse, Databricks) — no ingestion, no SDK.

Fits alongside existing warehouse-native BI peers in the section (Lightdash, Metabase, Count, Redash).

Repo: https://github.com/stratif-io/stratif.io