### PR TITLE
Add rawquery to SQL-like processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ You can read more about this distinction on Prof. Daniel Abadi's blog: [Distingu
 * [Invantive SQL](https://documentation.invantive.com/2017R2/invantive-sql-grammar/invantive-sql-grammar-17.30.html) - SQL engine for online and on-premise use with integrated local data replication and 70+ connectors.
 * [PipelineDB](https://www.pipelinedb.com/) - an open-source relational database that runs SQL queries continuously on streams, incrementally storing results in tables.
 * [Pivotal HDB](https://pivotal.io/pivotal-hdb) - SQL-like data warehouse system for Hadoop.
+* [rawquery](https://rawquery.dev) - managed lakehouse with DuckDB query engine over Apache Iceberg tables on S3, exposed via Postgres wire protocol.
 * [RainstorDB](http://rainstor.com/products/rainstor-database/) - database for storing petabyte-scale volumes of structured and semi-structured data.
 * [Spark Catalyst](https://github.com/apache/spark/tree/master/sql) - is a Query Optimization Framework for Spark and Shark.
 * [SparkSQL](https://databricks.com/blog/2014/03/26/spark-sql-manipulating-structured-data-using-spark-2.html) - Manipulating Structured Data Using Spark.


### PR DESCRIPTION
Adds rawquery to the SQL-like processing section.

[rawquery](https://rawquery.dev) is a managed lakehouse: DuckDB as the query engine, Apache Iceberg as the table format (already on this list), S3 for storage, Nessie as the catalog. Clients connect via Postgres wire protocol, a CLI, or a Python/REST API.

Sits next to Dremio and PrestoDB conceptually — interactive SQL on object storage.