### PR TITLE
Add chDB to SQL-like processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ You can read more about this distinction on Prof. Daniel Abadi's blog: [Distingu
 * [Apache Calcite](http://calcite.apache.org/) - framework that allows efficient translation of queries involving heterogeneous and federated data.
 * [Apache Phoenix](http://phoenix.apache.org/index.html) - SQL skin over HBase.
 * [Aster Database](http://www.teradata.com/products-and-services/Teradata-Aster/teradata-aster-database) - SQL-like analytic processing for MapReduce.
+* [chDB](https://github.com/chdb-io/chdb) - in-process OLAP SQL engine powered by ClickHouse, callable from Python with native pandas/Arrow DataFrame interop.
 * [Cloudera Impala](https://www.cloudera.com/products/apache-hadoop/impala.html) - framework for interactive analysis, Inspired by Dremel.
 * [Concurrent Lingual](http://www.cascading.org/projects/lingual/) - SQL-like query language for Cascading.
 * [Datasalt Splout SQL](http://www.datasalt.com/products/splout-sql/) - full SQL query engine for big datasets.


### PR DESCRIPTION
Adds chDB to the SQL-like processing section.

chDB is an in-process OLAP SQL engine powered by ClickHouse. It runs the
full ClickHouse SQL dialect (1000+ functions) in your Python process,
reads Parquet/CSV/JSON files directly, and references pandas DataFrames
in SQL with zero-copy.

- Repo: https://github.com/chdb-io/chdb
- License: Apache-2.0
- Stars: 2,690
- PyPI: chdb v4.1.8 (2026-05-22)
- Active: last commit 2026-05-27

Inserted alphabetically between "Aster Database" and "Cloudera Impala".