### PR TITLE
Add Duckle to Data Ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,7 @@ You can read more about this distinction on Prof. Daniel Abadi's blog: [Distingu
 * [DataRaven](https://dataraven.io/) - managed cloud object storage transfers for data ingestion workflows.
 * [DBConvert Streams](https://streams.dbconvert.com/cdc-replication/) - self-hosted CDC replication and database migration tool.
 * [Debezium](https://debezium.io/) - open-source distributed platform for change data capture.
+* [Duckle](https://github.com/SouravRoy-ETL/duckle) - open-source visual ETL/ELT studio that compiles pipelines to DuckDB SQL, with 300+ connectors and a built-in MCP server.
 * [Embulk](http://www.embulk.org) - open-source bulk data loader that helps data transfer between various databases, storages, file formats, and cloud services.
 * [Estuary](https://estuary.dev) - SaaS platform based on Gazette with plug-and-play connectors.
 * [Facebook Scribe](https://github.com/facebookarchive/scribe) - streamed log data aggregator.

--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ You can read more about this distinction on Prof. Daniel Abadi's blog: [Distingu
 * [DataRaven](https://dataraven.io/) - managed cloud object storage transfers for data ingestion workflows.
 * [DBConvert Streams](https://streams.dbconvert.com/cdc-replication/) - self-hosted CDC replication and database migration tool.
 * [Debezium](https://debezium.io/) - open-source distributed platform for change data capture.
-* [Duckle](https://github.com/SouravRoy-ETL/duckle) - open-source visual ETL/ELT studio that compiles pipelines to DuckDB SQL, with 300+ connectors and a built-in MCP server.
+* [Duckle](https://github.com/slothflowlabs/duckle) - open-source visual ETL/ELT platform built on DuckDB with connectors, data quality checks, and lineage.
 * [Embulk](http://www.embulk.org) - open-source bulk data loader that helps data transfer between various databases, storages, file formats, and cloud services.
 * [Estuary](https://estuary.dev) - SaaS platform based on Gazette with plug-and-play connectors.
 * [Facebook Scribe](https://github.com/facebookarchive/scribe) - streamed log data aggregator.


### PR DESCRIPTION
Adds [Duckle](https://github.com/SouravRoy-ETL/duckle) under **Data Ingestion**, alphabetically after Debezium and before Embulk.

Duckle is an open-source visual ETL/ELT studio that compiles pipelines to DuckDB SQL, with 300+ connectors and a built-in MCP server.