### PR TITLE
Add Zvec to Vector Databases section

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ You can read more about this distinction on Prof. Daniel Abadi's blog: [Distingu
 * [Milvus](https://github.com/milvus-io/milvus) - open-source vector database for scalable similarity search.
 * [Qdrant](https://qdrant.tech/) - vector database and similarity search engine with REST, gRPC, and client SDKs.
 * [Weaviate](https://weaviate.io/) - open-source vector database for semantic search with structured filtering.
-* [Zvec](https://github.com/alibaba/zvec) - embedded vector database for on-device RAG and edge AI, the SQLite of vector databases.
+* [Zvec](https://github.com/alibaba/zvec) - open-source, in-process vector database for dense, sparse, and hybrid similarity search.
 
 ## Data Ingestion
 * [redpanda](https://vectorized.io/redpanda) - A Kafka® replacement for mission critical systems; 10x faster. Written in C++.

--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ You can read more about this distinction on Prof. Daniel Abadi's blog: [Distingu
 * [Milvus](https://github.com/milvus-io/milvus) - open-source vector database for scalable similarity search.
 * [Qdrant](https://qdrant.tech/) - vector database and similarity search engine with REST, gRPC, and client SDKs.
 * [Weaviate](https://weaviate.io/) - open-source vector database for semantic search with structured filtering.
+* [Zvec](https://github.com/alibaba/zvec) - embedded vector database for on-device RAG and edge AI, the SQLite of vector databases.
 
 ## Data Ingestion
 * [redpanda](https://vectorized.io/redpanda) - A Kafka® replacement for mission critical systems; 10x faster. Written in C++.


### PR DESCRIPTION
## Project: [Zvec](https://github.com/alibaba/zvec)

Zvec is an open-source embedded vector database by Alibaba Tongyi Lab — the SQLite of vector databases. It runs in-process with zero external dependencies, just `pip install zvec`.

### Why it fits here

- Embedded, serverless vector database with zero-config deployment
- 12,500+ GitHub stars, actively maintained (latest: v0.5.1, June 2026)
- Built on Alibaba production-proven Proxima engine
- Python SDK plus Go, Rust, and Dart bindings
- Similar to Chroma, LanceDB, Milvus, Qdrant, and Weaviate already listed